### PR TITLE
Package debug symbols for AL builds

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -245,6 +245,13 @@ Requires: %{name}-devel%{?1}%{?_isa} = %{epoch}:%{version}-%{release}
 %description jmods
 Amazon Corretto's packaging of the OpenJDK ${java_spec_version} jmods.
 
+%package debugsymbols
+Summary: Amazon Corretto ${java_spec_version} zipped debug symbols
+Group: Development
+
+%description debugsymbols
+Amazon Corretto's packaging of the OpenJDK ${java_spec_version} debug symbols.
+
 %prep
 %setup -q -n src -c
 
@@ -284,7 +291,7 @@ bash ./configure \\
         --with-vendor-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-vendor-vm-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-debug-level=$debug_level \\
-        --with-native-debug-symbols=none
+        --with-native-debug-symbols=zipped
 
 make images
 make LOG=debug docs
@@ -431,6 +438,9 @@ fi
 %exclude %{java_lib}/libawt_xawt.so
 %exclude %{java_lib}/libjawt.so
 %exclude %{java_lib}/libsplashscreen.so
+# Exclude debug symbol files
+%exclude %{java_home}/lib/*.diz
+%exclude %{java_home}/lib/server/*.diz
 
 %files devel
 %{java_home}/bin/jar
@@ -496,7 +506,15 @@ fi
 %doc %{java_imgdir}/docs/specs
 %license %{java_imgdir}/docs/legal
 
+%files debugsymbols
+%{java_home}/bin/*.diz
+%{java_home}/lib/*.diz
+%{java_home}/lib/server/*.diz
+
 %changelog
+* Mon Aug 5 2024 Daniel Hu <costmuch@amazon.com>
+- Add package debug symbols
+
 * Mon Oct 10 2022 Dan Lutker <lutkerd@amazon.com>
 - Fix provides to include public shared libs
 


### PR DESCRIPTION
### Description
Clean backport of "Package debug symbols for AL builds"

### Related issues
https://github.com/corretto/corretto-jdk/pull/117

### Motivation and context
Adds debug symbols rpm package for AL builds

### How has this been tested?
Ran on internal pipelines, confirmed working for AL2023 on x64

### Platform information
    Works on OS: AL2023
    Applies to version 23.0.0.35.1


### Additional context
