### PR TITLE
8345296: AArch64: VM crashes with SIGILL when prctl is disallowed

### DIFF
--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -166,7 +166,13 @@ class FloatRegister {
     max_slots_per_register  =  4,
     save_slots_per_register =  2,
     slots_per_neon_register =  4,
-    extra_save_slots_per_neon_register = slots_per_neon_register - save_slots_per_register
+    extra_save_slots_per_neon_register = slots_per_neon_register - save_slots_per_register,
+    neon_vl = 16,
+    // VLmax: The maximum sve vector length is determined by the hardware
+    // sve_vl_min <= VLmax <= sve_vl_max.
+    sve_vl_min = 16,
+    // Maximum supported vector length across all CPUs
+    sve_vl_max = 256
   };
 
   class FloatRegisterImpl: public AbstractRegisterImpl {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "pauth_aarch64.hpp"
+#include "register_aarch64.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
@@ -436,7 +437,19 @@ void VM_Version::initialize() {
   }
 
   if (UseSVE > 0) {
-    _initial_sve_vector_length = get_current_sve_vector_length();
+    int vl = get_current_sve_vector_length();
+    if (vl < 0) {
+      warning("Unable to get SVE vector length on this system. "
+              "Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.");
+      FLAG_SET_DEFAULT(UseSVE, 0);
+    } else if ((vl == 0) || ((vl % FloatRegister::sve_vl_min) != 0) || !is_power_of_2(vl)) {
+      warning("Detected SVE vector length (%d) should be a power of two and a multiple of %d. "
+              "Disabling SVE. Specify -XX:UseSVE=0 to shun this warning.",
+              vl, FloatRegister::sve_vl_min);
+      FLAG_SET_DEFAULT(UseSVE, 0);
+    } else {
+      _initial_sve_vector_length = vl;
+    }
   }
 
   // This machine allows unaligned memory accesses


### PR DESCRIPTION
Backport 3c60f0b2bb75150d49da9ab94d88b767275de5e2

Not waiting for upstream merge of https://github.com/openjdk/jdk21u-dev/pull/1222 because of the impact:

> We have caught this in some prod environments, where prctl is forbidden by the sandboxing mechanism. This fails the JVM

Does not apply cleanly, the backport depends on `FloatRegister` changes from [JDK-8339063](https://bugs.openjdk.org/browse/JDK-8339063) which are included in `src/hotspot/cpu/aarch64/register_aarch64.hpp`.


Additional testing:

- [x] Verified the bug is fixed with the seccomp repro from [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296?focusedId=14727386&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14727386): Segfault without the patch, works with.